### PR TITLE
Fixes uglify error

### DIFF
--- a/browser/js/home/home.js
+++ b/browser/js/home/home.js
@@ -6,7 +6,7 @@ app.config(function ($stateProvider) {
     });
 })
 
-app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
+app.controller('HomeCtrl', function($scope, $uibModal){
 
   var smodal; 
   var lmodal;
@@ -72,4 +72,4 @@ app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
 
 		}]
  	}
-}])
+})

--- a/browser/js/home/home.js
+++ b/browser/js/home/home.js
@@ -27,7 +27,7 @@ app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
 		animation: true,
 		size: "lg",
 		templateUrl: 'js/signup/signup.html',
-		controller: function($scope, $uibModalInstance, UserFactory, AuthService){
+		controller: ['$scope', '$uibModalInstance', 'UserFactory', 'AuthService', function($scope, $uibModalInstance, UserFactory, AuthService){
 
 		    $scope.sendSignup = function(signup){
 		    var newLogin = {username: signup.username, email: signup.email, password: signup.password};
@@ -45,14 +45,14 @@ app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
 			lmodal = $uibModal.open(login)
 		  }
 
-		}
+		}]
 	}
 
 	var login = {
 		animation: true,
 	    size: "lg",
 	    templateUrl: 'js/login/login.html',
-	    controller: function($scope, $uibModalInstance, AuthService, $state){
+	    controller: ['$scope', '$uibModalInstance', 'AuthService', '$state', function($scope, $uibModalInstance, AuthService, $state){
 
 	    $scope.login = {};
 
@@ -70,6 +70,6 @@ app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
 
 		}
 
-		}
+		}]
  	}
 }])

--- a/browser/js/home/home.js
+++ b/browser/js/home/home.js
@@ -6,7 +6,7 @@ app.config(function ($stateProvider) {
     });
 })
 
-app.controller('HomeCtrl', function($scope, $uibModal){
+app.controller('HomeCtrl', ['$scope, $uibModal', function($scope, $uibModal){
 
   var smodal; 
   var lmodal;
@@ -72,4 +72,4 @@ app.controller('HomeCtrl', function($scope, $uibModal){
 
 		}
  	}
-})
+}])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('buildJSProduction', function () {
         .pipe(concat('main.js'))
         .pipe(babel())
         .pipe(ngAnnotate())
-        .pipe(uglify())
+        .pipe(uglify({ output : { beautify : true }}))
         .pipe(gulp.dest('./public'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('buildJSProduction', function () {
         .pipe(concat('main.js'))
         .pipe(babel())
         .pipe(ngAnnotate())
-        .pipe(uglify({ output : { beautify : true }}))
+        .pipe(uglify())
         .pipe(gulp.dest('./public'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('buildJSProduction', function () {
         .pipe(concat('main.js'))
         .pipe(babel())
         .pipe(ngAnnotate())
-        // .pipe(uglify())
+        .pipe(uglify())
         .pipe(gulp.dest('./public'));
 });
 


### PR DESCRIPTION
Ng-annotate does NOT add annotations to modal controllers, so those modals were getting broken by Uglify... just had to go in and manually add annotations to our signup and login controllers, and that fixed everything.
